### PR TITLE
Lets2

### DIFF
--- a/tasks/setup_freeipa.yml
+++ b/tasks/setup_freeipa.yml
@@ -49,6 +49,20 @@
   become: true
   when: freeipa_enabled|bool
 
+- name: Ensure freeipa config files installed installed
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/freeipa-server/{{ item }}.j2"
+    dest: "{{ freeipa_config_path }}/{{ item }}"
+    owner: "{{ freeipa_user_uid }}"
+    group: "{{ freeipa_user_gid }}"
+    mode: 0640
+  with_items:
+    - env-freeipa
+    - ipa-httpd.cnf
+  become: true
+  when:
+    - freeipa_enabled|bool
+
 # - name: Create freeipa network
 #  shell: podman network create "{{ freeipa_podman_network }}"
 #  become: yes

--- a/tasks/setup_letsencrypt.yml
+++ b/tasks/setup_letsencrypt.yml
@@ -84,6 +84,17 @@
   when: not letsencrypt_cert.stat.exists
   with_items: "{{ letsencrypt_certbot_create_standalone_stop_services }}"
 
+- name: Ensure freeipa systemd files are installed installed
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/freeipa-letsencrypt/{{ item }}.j2"
+    dest: "/usr/local/bin"
+    mode: 0750
+  with_items:
+    - renew-letsencrypt.sh
+  become: true
+  when:
+    - letsencrypt_certbot_enabled|bool
+
 
 - name: Ensure freeipa systemd files are installed installed
   ansible.builtin.template:

--- a/tasks/setup_letsencrypt.yml
+++ b/tasks/setup_letsencrypt.yml
@@ -137,6 +137,13 @@
       with_items:
         - freeipa-letsencrypt.service
         - freeipa-letsencrypt.timer
+
+    - name: Ensure freeipa-letsencrypt.sh doesn't exist
+      ansible.builtin.file:
+        path: "/usr/local/bin/{{ item }}"
+        state: absent
+      with_items:
+        - renew-letsencrypt.sh
   when:
     - (not letsencrypt_certbot_enabled|bool)
     - freeipa_letsencrypt.stat.exists|bool

--- a/tasks/setup_letsencrypt.yml
+++ b/tasks/setup_letsencrypt.yml
@@ -87,7 +87,7 @@
 - name: Ensure freeipa systemd files are installed installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/freeipa-letsencrypt/{{ item }}.j2"
-    dest: "/usr/local/bin"
+    dest: "/usr/local/bin/{{ item }}"
     mode: 0750
   with_items:
     - renew-letsencrypt.sh

--- a/tasks/setup_letsencrypt.yml
+++ b/tasks/setup_letsencrypt.yml
@@ -108,7 +108,7 @@
   ansible.builtin.stat:
     path: "{{ freeipa_systemd_path }}/freeipa-letsencrypt.timer"
   register: freeipa_letsencrypt
-  when: "not letsencrypt_certbot_enabled|bool or not freeipa_haproxy_enabled|bool"
+  when: "not letsencrypt_certbot_enabled|bool"
 
 - name: Delete freeipa-letsencrypt.timer
   block:
@@ -127,5 +127,5 @@
         - freeipa-letsencrypt.service
         - freeipa-letsencrypt.timer
   when:
-    - (not letsencrypt_certbot_enabled|bool) or (not freeipa_haproxy_enabled|bool)
+    - (not letsencrypt_certbot_enabled|bool)
     - freeipa_letsencrypt.stat.exists|bool

--- a/templates/freeipa-letsencrypt/renew-letsencrypt.sh.j2
+++ b/templates/freeipa-letsencrypt/renew-letsencrypt.sh.j2
@@ -1,0 +1,44 @@
+#jinja2: lstrip_blocks: "True"
+#!/usr/bin/bash
+set -o nounset -o errexit
+
+WORKDIR=$(dirname "$(realpath $0)")
+EMAIL="{{ letsencrypt_certbot_admin_email }}"
+
+### cron
+# check that the cert will last at least 2 days from now to prevent too frequent renewal
+# comment out this line for the first run
+if [ "${1:-renew}" != "--first-time" ]
+then
+	start_timestamp=`date +%s --date="$(openssl x509 -startdate -noout -in /var/lib/ipa/certs/httpd.crt | cut -d= -f2)"`
+	now_timestamp=`date +%s`
+	let diff=($now_timestamp-$start_timestamp)/86400
+	if [ "$diff" -lt "2" ]; then
+		exit 0
+	fi
+fi
+cd "$WORKDIR"
+# cert renewal is needed if we reached this line
+
+# cleanup
+rm -f "$WORKDIR"/*.pem
+rm -f "$WORKDIR"/httpd-csr.*
+
+# generate CSR
+OPENSSL_PASSWD_FILE="/var/lib/ipa/passwds/$HOSTNAME-443-RSA"
+[ -f "$OPENSSL_PASSWD_FILE" ] && OPENSSL_EXTRA_ARGS="-passout file:$OPENSSL_PASSWD_FILE" || OPENSSL_EXTRA_ARGS=""
+openssl req -new -sha256 -config "$WORKDIR/ipa-httpd.cnf"  -key /var/lib/ipa/private/httpd.key -out "$WORKDIR/httpd-csr.der" $OPENSSL_EXTRA_ARGS
+
+# httpd process prevents letsencrypt from working, stop it
+service httpd stop
+
+# get a new cert
+letsencrypt certonly --standalone --csr "$WORKDIR/httpd-csr.der" --email "$EMAIL" --agree-tos
+
+# replace the cert
+cp /var/lib/ipa/certs/httpd.crt /var/lib/ipa/certs/httpd.crt.bkp
+mv -f "$WORKDIR/0000_cert.pem" /var/lib/ipa/certs/httpd.crt
+restorecon -v /var/lib/ipa/certs/httpd.crt
+
+# start httpd with the new cert
+service httpd start

--- a/templates/freeipa-server/ipa-httpd.cnf.j2
+++ b/templates/freeipa-server/ipa-httpd.cnf.j2
@@ -1,0 +1,19 @@
+#jinja2: lstrip_blocks: "True"
+# the fully qualified server (or service) name
+FQDN = {{ freeipa_domain_name }}
+ALTNAMES = DNS:$FQDN
+
+# --- no modifications required below ---
+[ req ]
+default_bits = 2048
+default_md = sha256
+prompt = no
+encrypt_key = no
+distinguished_name = dn
+req_extensions = req_ext
+
+[ dn ]
+CN = $FQDN
+
+[ req_ext ]
+subjectAltName = $ALTNAMES


### PR DESCRIPTION
lets encrypt doesnt error out

Known bugs

admin@ip-10-0-1-156:~$ sudo renew-letsencrypt.sh /freeipa/letsencrypt/working
Can't open /var/lib/ipa/certs/httpd.crt for reading, No such file or directory
139933015754048:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('/var/lib/ipa/certs/httpd.crt','r')
139933015754048:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76: